### PR TITLE
Improved v4 CSharp template to reduce clashes with argument names and to support async binding

### DIFF
--- a/src/Unchase.OData.ConnectedService/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/Unchase.OData.ConnectedService/CodeGeneration/V4CodeGenDescriptor.cs
@@ -141,6 +141,7 @@ namespace Unchase.OData.ConnectedService.CodeGeneration
             {
                 MetadataDocumentUri = MetadataUri,
                 UseDataServiceCollection = this.ServiceConfiguration.UseDataServiceCollection,
+                UseAsyncDataServiceCollection = this.ServiceConfiguration.UseAsyncDataServiceCollection,
                 TargetLanguage = this.ServiceConfiguration.LanguageOption == LanguageOption.GenerateCSharpCode ? ODataT4CodeGenerator.LanguageOption.CSharp : ODataT4CodeGenerator.LanguageOption.VB,
                 IgnoreUnexpectedElementsAndAttributes = this.ServiceConfiguration.IgnoreUnexpectedElementsAndAttributes,
                 EnableNamingAlias = this.ServiceConfiguration.EnableNamingAlias,

--- a/src/Unchase.OData.ConnectedService/Models/ServiceConfiguration.cs
+++ b/src/Unchase.OData.ConnectedService/Models/ServiceConfiguration.cs
@@ -26,6 +26,11 @@ namespace Unchase.OData.ConnectedService.Models
         public string NamespacePrefix { get; set; }
 
         public bool UseDataServiceCollection { get; set; }
+        /// <summary>
+        /// Change the INotifyPropertyChanged Implementation to support async operations with synchronous event callbacks
+        /// </summary>
+        /// <remarks>This should only be set to true if the <see cref="UseDataServiceCollection"/> is also true.</remarks>
+        public bool UseAsyncDataServiceCollection { get; set; }
 
         public bool OpenGeneratedFilesOnComplete { get; set; }
 

--- a/src/Unchase.OData.ConnectedService/Models/UserSettings.cs
+++ b/src/Unchase.OData.ConnectedService/Models/UserSettings.cs
@@ -42,11 +42,14 @@ namespace Unchase.OData.ConnectedService.Models
         public LanguageOption LanguageOption { get; set; }
 
         /// <summary>
+        /// Implement INotifyPropertyChanged in generated proxies to support change tracking
+        /// </summary>
+        [DataMember]
+        public bool UseDataServiceCollection { get; set; }
+        /// <summary>
         /// Change the INotifyPropertyChanged Implementation to support async operations with synchronous event callbacks
         /// </summary>
         /// <remarks>This should only be set to true if the <see cref="UseDataServiceCollection"/> is also true.</remarks>
-        [DataMember]
-        public bool UseDataServiceCollection { get; set; }
         [DataMember]
         public bool UseAsyncDataServiceCollection { get; set; }
 

--- a/src/Unchase.OData.ConnectedService/Models/UserSettings.cs
+++ b/src/Unchase.OData.ConnectedService/Models/UserSettings.cs
@@ -41,8 +41,14 @@ namespace Unchase.OData.ConnectedService.Models
         [DataMember]
         public LanguageOption LanguageOption { get; set; }
 
+        /// <summary>
+        /// Change the INotifyPropertyChanged Implementation to support async operations with synchronous event callbacks
+        /// </summary>
+        /// <remarks>This should only be set to true if the <see cref="UseDataServiceCollection"/> is also true.</remarks>
         [DataMember]
         public bool UseDataServiceCollection { get; set; }
+        [DataMember]
+        public bool UseAsyncDataServiceCollection { get; set; }
 
         [DataMember]
         public string GeneratedFileNamePrefix { get; set; }

--- a/src/Unchase.OData.ConnectedService/Templates/ODataT4CodeGenerator.cs
+++ b/src/Unchase.OData.ConnectedService/Templates/ODataT4CodeGenerator.cs
@@ -5005,7 +5005,7 @@ this.Write(" as ");
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
 this.Write(" specified by key from an entity set\r\n        /// </summary>\r\n        /// <param " +
-        "name=\"source\">source entity set</param>\r\n        /// <param name=\"keys\">dictiona" +
+        "name=\"_source\">source entity set</param>\r\n        /// <param name=\"keys\">dictiona" +
         "ry with the names and values of keys</param>\r\n        public static ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
@@ -5014,13 +5014,13 @@ this.Write(" ByKey(this global::Microsoft.OData.Client.DataServiceQuery<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
 
-this.Write("> source, global::System.Collections.Generic.Dictionary<string, object> keys)\r\n  " +
+this.Write("> _source, global::System.Collections.Generic.Dictionary<string, object> keys)\r\n  " +
         "      {\r\n            return new ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetK" +
-        "eyString(source.Context, keys)));\r\n        }\r\n        /// <summary>\r\n        ///" +
+this.Write("(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetK" +
+        "eyString(_source.Context, keys)));\r\n        }\r\n        /// <summary>\r\n        ///" +
         " Get an entity of type ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
@@ -5030,7 +5030,7 @@ this.Write(" as ");
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
 this.Write(" specified by key from an entity set\r\n        /// </summary>\r\n        /// <param " +
-        "name=\"source\">source entity set</param>\r\n");
+        "name=\"_source\">source entity set</param>\r\n");
 
 
         foreach (var key in keys)
@@ -5057,7 +5057,7 @@ this.Write(" ByKey(this global::Microsoft.OData.Client.DataServiceQuery<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
 
-this.Write("> source,\r\n            ");
+this.Write("> _source,\r\n            ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(keyParameters));
 
@@ -5071,8 +5071,8 @@ this.Write("\r\n            };\r\n            return new ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetK" +
-        "eyString(source.Context, keys)));\r\n        }\r\n");
+this.Write("(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetK" +
+        "eyString(_source.Context, keys)));\r\n        }\r\n");
 
 
     }
@@ -5101,7 +5101,7 @@ this.Write("(this global::Microsoft.OData.Client.DataServiceQuerySingle<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(baseTypeName));
 
-this.Write("> source)\r\n        {\r\n            global::Microsoft.OData.Client.DataServiceQuery" +
+this.Write("> _source)\r\n        {\r\n            global::Microsoft.OData.Client.DataServiceQuery" +
         "Single<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
@@ -5114,7 +5114,7 @@ this.Write(">();\r\n            return new ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, query.GetPath(null));\r\n        }\r\n");
+this.Write("(_source.Context, query.GetPath(null));\r\n        }\r\n");
 
 
     }
@@ -5153,19 +5153,19 @@ this.Write("(this ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(boundTypeName));
 
-this.Write(" source");
+this.Write(" _source");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters));
 
 this.Write(this.ToStringHelper.ToStringWithCulture(useEntityReference ? ", bool useEntityReference = false" : string.Empty));
 
-this.Write(")\r\n        {\r\n            if (!source.IsComposable)\r\n            {\r\n             " +
+this.Write(")\r\n        {\r\n            if (!_source.IsComposable)\r\n            {\r\n             " +
         "   throw new global::System.NotSupportedException(\"The previous function is not " +
         "composable.\");\r\n            }\r\n\r\n            return ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(isReturnEntity ? "new " + returnTypeNameWithSingleSuffix + "(" : string.Empty));
 
-this.Write("source.CreateFunctionQuerySingle<");
+this.Write("_source.CreateFunctionQuerySingle<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
@@ -5226,13 +5226,13 @@ this.Write("(this ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(boundTypeName));
 
-this.Write(" source");
+this.Write(" _source");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters));
 
 this.Write(this.ToStringHelper.ToStringWithCulture(useEntityReference ? ", bool useEntityReference = true" : string.Empty));
 
-this.Write(")\r\n        {\r\n            if (!source.IsComposable)\r\n            {\r\n             " +
+this.Write(")\r\n        {\r\n            if (!_source.IsComposable)\r\n            {\r\n             " +
         "   throw new global::System.NotSupportedException(\"The previous function is not " +
         "composable.\");\r\n            }\r\n\r\n            return source.CreateFunctionQuery<");
 
@@ -5291,17 +5291,17 @@ this.Write("(this ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(boundSourceType));
 
-this.Write(" source");
+this.Write(" _source");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters));
 
-this.Write(")\r\n        {\r\n            if (!source.IsComposable)\r\n            {\r\n             " +
+this.Write(")\r\n        {\r\n            if (!_source.IsComposable)\r\n            {\r\n             " +
         "   throw new global::System.NotSupportedException(\"The previous function is not " +
         "composable.\");\r\n            }\r\n\r\n            return new ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, source.AppendRequestUri(\"");
+this.Write("(_source.Context, _source.AppendRequestUri(\"");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(fullNamespace));
 

--- a/src/Unchase.OData.ConnectedService/Templates/ODataT4CodeGenerator.cs
+++ b/src/Unchase.OData.ConnectedService/Templates/ODataT4CodeGenerator.cs
@@ -3057,6 +3057,12 @@ internal static class Utils
                     {
                         defaultValue = "\"" + defaultValue + "\"";
                     }
+                    else if (valueClrType.Equals(clientTemplate.BooleanTypeName))
+                    {
+                        // EDMX specifies boolean defaults with capital letter, C# needs this string to be lower case.
+                        if (isCSharpTemplate)
+                            defaultValue = defaultValue.ToLower();
+                    }
                     else if (valueClrType.Equals(clientTemplate.BinaryTypeName))
                     {
                         defaultValue = "System.Text.Encoding.UTF8.GetBytes(\"" + defaultValue + "\")";
@@ -5088,7 +5094,7 @@ this.Write(" to its derived type ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
 
-this.Write("\r\n        /// </summary>\r\n        /// <param name=\"source\">source entity</param>\r" +
+this.Write("\r\n        /// </summary>\r\n        /// <param name=\"_source\">source entity</param>\r" +
         "\n        public static ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
@@ -5106,7 +5112,7 @@ this.Write("> _source)\r\n        {\r\n            global::Microsoft.OData.Clien
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
 
-this.Write("> query = source.CastTo<");
+this.Write("> query = _source.CastTo<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
 
@@ -5234,7 +5240,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(useEntityReference ? ", bool 
 
 this.Write(")\r\n        {\r\n            if (!_source.IsComposable)\r\n            {\r\n             " +
         "   throw new global::System.NotSupportedException(\"The previous function is not " +
-        "composable.\");\r\n            }\r\n\r\n            return source.CreateFunctionQuery<");
+        "composable.\");\r\n            }\r\n\r\n            return _source.CreateFunctionQuery<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
@@ -7005,10 +7011,10 @@ this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
 this.Write(@" specified by key from an entity set
         ''' </summary>
-        ''' <param name=""source"">source entity set</param>
+        ''' <param name=""_source"">source entity set</param>
         ''' <param name=""keys"">dictionary with the names and values of keys</param>
         <Global.System.Runtime.CompilerServices.Extension()>
-        Public Function ByKey(ByVal source As Global.Microsoft.OData.Client.DataServiceQuery(Of ");
+        Public Function ByKey(ByVal _source As Global.Microsoft.OData.Client.DataServiceQuery(Of ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
 
@@ -7021,8 +7027,8 @@ this.Write("\r\n            Return New ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, source.GetKeyPath(Global.Microsoft.OData.Client.Serializer.GetKe" +
-        "yString(source.Context, keys)))\r\n        End Function\r\n        \'\'\' <summary>\r\n  " +
+this.Write("(_source.Context, _source.GetKeyPath(Global.Microsoft.OData.Client.Serializer.GetKe" +
+        "yString(_source.Context, keys)))\r\n        End Function\r\n        \'\'\' <summary>\r\n  " +
         "      \'\'\' Get an entity of type ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
@@ -7032,7 +7038,7 @@ this.Write(" as ");
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
 this.Write(" specified by key from an entity set\r\n        \'\'\' </summary>\r\n        \'\'\' <param " +
-        "name=\"source\">source entity set</param>\r\n");
+        "name=\"_source\">source entity set</param>\r\n");
 
 
         foreach (var key in keys)
@@ -7052,7 +7058,7 @@ this.Write("</param>\r\n");
         }
 
 this.Write("        <Global.System.Runtime.CompilerServices.Extension()>\r\n        Public Func" +
-        "tion ByKey(ByVal source As Global.Microsoft.OData.Client.DataServiceQuery(Of ");
+        "tion ByKey(ByVal _source As Global.Microsoft.OData.Client.DataServiceQuery(Of ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
 
@@ -7074,8 +7080,8 @@ this.Write("\r\n            }\r\n            Return New ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, source.GetKeyPath(Global.Microsoft.OData.Client.Serializer.GetKe" +
-        "yString(source.Context, keys)))\r\n        End Function\r\n");
+this.Write("(_source.Context, _source.GetKeyPath(Global.Microsoft.OData.Client.Serializer.GetKe" +
+        "yString(_source.Context, keys)))\r\n        End Function\r\n");
 
 
     }
@@ -7091,13 +7097,13 @@ this.Write(" to its derived type ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
 
-this.Write("\r\n        \'\'\' </summary>\r\n        \'\'\' <param name=\"source\">source entity</param>\r" +
+this.Write("\r\n        \'\'\' </summary>\r\n        \'\'\' <param name=\"_source\">source entity</param>\r" +
         "\n        <Global.System.Runtime.CompilerServices.Extension()>\r\n        Public " +
         "Function CastTo");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeName));
 
-this.Write("(ByVal source As Global.Microsoft.OData.Client.DataServiceQuerySingle(Of ");
+this.Write("(ByVal _source As Global.Microsoft.OData.Client.DataServiceQuerySingle(Of ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(baseTypeName));
 
@@ -7110,7 +7116,7 @@ this.Write("\r\n            Dim query As Global.Microsoft.OData.Client.DataServi
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
 
-this.Write(") = source.CastTo(Of ");
+this.Write(") = _source.CastTo(Of ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
 
@@ -7118,7 +7124,7 @@ this.Write(")()\r\n            Return New ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, query.GetPath(Nothing))\r\n        End Function\r\n");
+this.Write("(_source.Context, query.GetPath(Nothing))\r\n        End Function\r\n");
 
 
     }
@@ -7150,7 +7156,7 @@ this.Write("        Public Function ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(functionName));
 
-this.Write("(ByVal source As ");
+this.Write("(ByVal _source As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(boundTypeName));
 
@@ -7162,13 +7168,13 @@ this.Write(") As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(isReturnEntity ? returnTypeNameWithSingleSuffix : string.Format(this.DataServiceQuerySingleStructureTemplate, returnTypeName)));
 
-this.Write("\r\n            If Not source.IsComposable Then\r\n                Throw New Global.S" +
+this.Write("\r\n            If Not _source.IsComposable Then\r\n                Throw New Global.S" +
         "ystem.NotSupportedException(\"The previous function is not composable.\")\r\n       " +
         "     End If\r\n            \r\n            Return ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(isReturnEntity ? "New " + returnTypeNameWithSingleSuffix + "(" : string.Empty));
 
-this.Write("source.CreateFunctionQuerySingle(");
+this.Write("_source.CreateFunctionQuerySingle(");
 
 this.Write(this.ToStringHelper.ToStringWithCulture("Of " + returnTypeName));
 
@@ -7222,7 +7228,7 @@ this.Write("        Public Function ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(functionName));
 
-this.Write("(ByVal source As ");
+this.Write("(ByVal _source As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(boundTypeName));
 
@@ -7234,9 +7240,9 @@ this.Write(") As Global.Microsoft.OData.Client.DataServiceQuery(Of ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write(")\r\n            If Not source.IsComposable Then\r\n                Throw New Global." +
+this.Write(")\r\n            If Not _source.IsComposable Then\r\n                Throw New Global." +
         "System.NotSupportedException(\"The previous function is not composable.\")\r\n      " +
-        "      End If\r\n            \r\n            Return source.CreateFunctionQuery(Of ");
+        "      End If\r\n            \r\n            Return _source.CreateFunctionQuery(Of ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
@@ -7286,7 +7292,7 @@ this.Write("        Public Function ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(actionName));
 
-this.Write("(ByVal source As ");
+this.Write("(ByVal _source As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(boundSourceType));
 
@@ -7296,13 +7302,13 @@ this.Write(") As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("\r\n            If Not source.IsComposable Then\r\n                Throw New Global.S" +
+this.Write("\r\n            If Not _source.IsComposable Then\r\n                Throw New Global.S" +
         "ystem.NotSupportedException(\"The previous function is not composable.\")\r\n       " +
         "     End If\r\n            Return New ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("(source.Context, source.AppendRequestUri(\"");
+this.Write("(_source.Context, _source.AppendRequestUri(\"");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(fullNamespace));
 

--- a/src/Unchase.OData.ConnectedService/Unchase.OData.ConnectedService.csproj
+++ b/src/Unchase.OData.ConnectedService/Unchase.OData.ConnectedService.csproj
@@ -167,12 +167,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Templates\ODataT4CodeGenerator.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>ODataT4CodeGenerator1.cs</LastGenOutput>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Templates\ODataV3ExtensionsT4CodeGenerator.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ODataV3ExtensionsT4CodeGenerator.cs</LastGenOutput>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/Unchase.OData.ConnectedService/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/Unchase.OData.ConnectedService/ViewModels/AdvancedSettingsViewModel.cs
@@ -28,7 +28,38 @@ namespace Unchase.OData.ConnectedService.ViewModels
                 _useDataServiceCollection = value;
                 UserSettings.UseDataServiceCollection = value;
                 OnPropertyChanged(nameof(UseDataServiceCollection));
+                OnPropertyChanged(nameof(ShowAsyncDataServiceCollectionOption));
             }
+        }
+        #endregion
+
+        #region UseAsyncDataServiceCollection
+        private bool _useAsyncDataServiceCollection;
+
+        /// <summary>
+        /// Change the INotifyPropertyChanged Implementation to support async operations with synchronous event callbacks
+        /// </summary>
+        /// <remarks>This should only be set to true is the <see cref="UseDataServiceCollection"/> is also true.</remarks>
+        public bool UseAsyncDataServiceCollection
+        {
+            get => _useAsyncDataServiceCollection;
+            set
+            {
+                _useAsyncDataServiceCollection = value;
+                UserSettings.UseAsyncDataServiceCollection = value;
+                OnPropertyChanged(nameof(UseAsyncDataServiceCollection));
+            }
+        }
+        #endregion
+
+        #region  ShowAsyncDataServiceCollectionOption
+        /// <summary>
+        /// Show the advanced option for INotifyPropertyChanged notification that generates async and await compatible bindings 
+        /// only available in C# and when <see cref="UseDataServiceCollection"/> is enabled.
+        /// </summary>
+        public bool ShowAsyncDataServiceCollectionOption
+        {
+            get => this.UserSettings.LanguageOption == LanguageOption.GenerateCSharpCode && UseDataServiceCollection;
         }
         #endregion
 
@@ -235,6 +266,7 @@ namespace Unchase.OData.ConnectedService.ViewModels
 
             this.View = new AdvancedSettings(this.InternalWizard);
             this.UseDataServiceCollection = UserSettings.UseDataServiceCollection;
+            this.UseAsyncDataServiceCollection = UserSettings.UseAsyncDataServiceCollection;
             this.UseNamespacePrefix = UserSettings.UseNameSpacePrefix;
             this.NamespacePrefix = UserSettings.NamespacePrefix ?? Constants.DefaultNamespacePrefix;
             this.EnableNamingAlias = UserSettings.EnableNamingAlias;

--- a/src/Unchase.OData.ConnectedService/Views/AdvancedSettings.xaml
+++ b/src/Unchase.OData.ConnectedService/Views/AdvancedSettings.xaml
@@ -66,13 +66,25 @@
                     VerticalAlignment="Center"
                     Text="{Binding UserSettings.NamespacePrefix, Mode=TwoWay}"
                     TextWrapping="Wrap" />
-                <CheckBox
+                <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+                    <CheckBox
                     x:Name="UseDsc"
-                    Margin="0,5,0,0"
+                    
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
                     Content="Enable entity and property tracking."
                     IsChecked="{Binding UserSettings.UseDataServiceCollection, Mode=TwoWay}" />
+                    <TextBlock Margin="10,0,0,0">-</TextBlock>
+                    <CheckBox
+                    x:Name="UseAsyncDsc"
+                    Margin="10,0,0,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Content="Implement async binding base. (c# only)"
+                    Visibility="{Binding UserSettings.UseDataServiceCollection}"
+                    IsEnabled="{Binding UserSettings.ShowAsyncDataServiceCollectionOption}"
+                    IsChecked="{Binding UserSettings.UseAsyncDataServiceCollection, Mode=TwoWay}" />
+                </StackPanel>
                 <CheckBox
                     x:Name="SelectOperationImports"
                     Width="450"

--- a/src/Unchase.OData.ConnectedService/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/Unchase.OData.ConnectedService/Views/ConfigODataEndpoint.xaml.cs
@@ -85,6 +85,7 @@ namespace Unchase.OData.ConnectedService.Views
                 this.UserSettings.ExcludedOperationImportsNames = microsoftConnectedServiceData.ExtendedData?.ExcludedOperationImportsNames ?? this.UserSettings.ExcludedOperationImportsNames;
                 this.UserSettings.UseNameSpacePrefix = microsoftConnectedServiceData.ExtendedData?.UseNameSpacePrefix ?? this.UserSettings.UseNameSpacePrefix;
                 this.UserSettings.UseDataServiceCollection = microsoftConnectedServiceData.ExtendedData?.UseDataServiceCollection ?? this.UserSettings.UseDataServiceCollection;
+                this.UserSettings.UseAsyncDataServiceCollection = microsoftConnectedServiceData.ExtendedData?.UseAsyncDataServiceCollection ?? this.UserSettings.UseAsyncDataServiceCollection;
                 this.UserSettings.ServiceName = microsoftConnectedServiceData.ExtendedData?.ServiceName ?? this.UserSettings.ServiceName;
                 this.UserSettings.AcceptAllUntrustedCertificates = microsoftConnectedServiceData.ExtendedData?.AcceptAllUntrustedCertificates ?? this.UserSettings.AcceptAllUntrustedCertificates;
                 this.UserSettings.NamespacePrefix = microsoftConnectedServiceData.ExtendedData?.NamespacePrefix ?? this.UserSettings.NamespacePrefix;

--- a/src/Unchase.OData.ConnectedService/Wizard.cs
+++ b/src/Unchase.OData.ConnectedService/Wizard.cs
@@ -73,6 +73,7 @@ namespace Unchase.OData.ConnectedService
                 AdvancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNameSpacePrefix;
                 AdvancedSettingsViewModel.NamespacePrefix = serviceConfig.NamespacePrefix;
                 AdvancedSettingsViewModel.UseDataServiceCollection = serviceConfig.UseDataServiceCollection;
+                AdvancedSettingsViewModel.UseAsyncDataServiceCollection = serviceConfig.UseAsyncDataServiceCollection;
                 AdvancedSettingsViewModel.OperationImportsGenerator = serviceConfig.OperationImportsGenerator;
                 AdvancedSettingsViewModel.SelectOperationImports = serviceConfig.GenerateOperationImports;
                 AdvancedSettingsViewModel.ExcludedOperationImportsNames = serviceConfig.ExcludedOperationImportsNames;
@@ -100,6 +101,7 @@ namespace Unchase.OData.ConnectedService
                             advancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNameSpacePrefix;
                             advancedSettingsViewModel.NamespacePrefix = serviceConfig.NamespacePrefix;
                             advancedSettingsViewModel.UseDataServiceCollection = serviceConfig.UseDataServiceCollection;
+                            advancedSettingsViewModel.UseAsyncDataServiceCollection = serviceConfig.UseAsyncDataServiceCollection;
                             advancedSettingsViewModel.OperationImportsGenerator = serviceConfig.OperationImportsGenerator;
                             advancedSettingsViewModel.SelectOperationImports = serviceConfig.GenerateOperationImports;
                             advancedSettingsViewModel.ExcludedOperationImportsNames = serviceConfig.ExcludedOperationImportsNames;
@@ -252,6 +254,7 @@ namespace Unchase.OData.ConnectedService
             serviceConfiguration.Endpoint = ConfigODataEndpointViewModel.UserSettings.Endpoint;
             serviceConfiguration.EdmxVersion = ConfigODataEndpointViewModel.EdmxVersion;
             serviceConfiguration.UseDataServiceCollection = AdvancedSettingsViewModel.UserSettings.UseDataServiceCollection;
+            serviceConfiguration.UseAsyncDataServiceCollection = AdvancedSettingsViewModel.UserSettings.UseAsyncDataServiceCollection;
             serviceConfiguration.GeneratedFileNamePrefix = AdvancedSettingsViewModel.UserSettings.GeneratedFileNamePrefix;
             serviceConfiguration.UseNameSpacePrefix = AdvancedSettingsViewModel.UserSettings.UseNameSpacePrefix;
             serviceConfiguration.OpenGeneratedFilesOnComplete = ConfigODataEndpointViewModel.UserSettings.OpenGeneratedFilesOnComplete;


### PR DESCRIPTION
I apologize in advance for including two feature changes in the same PR :)
1.  The name of the type parameter in the generated extensions methods was called 'source', the generated proxy classes would not compile if any of the actions or functions on the service had a parameter also named 'source'. This was resolved by renaming the hardcoded extension type parameter to '_source'.

    - This change was implemented in both _C#_ template and _VB_.

2. An alternate implementation for INotifyPropertyChanged has been added, along with a tickbox in the advanced settings dialog to toggle the implementation.
![image](https://user-images.githubusercontent.com/7519539/72994459-3f148480-3e4b-11ea-9f99-c4e5e3de0114.png)

    - This setting is only visible _IF_ the `Enable entity and property tracking` setting is enabled.
    - This setting is only enabled for C# code generation at this point in time.

The implementation is a blatant rip off from this Stack Overflow response: https://stackoverflow.com/a/45422891/1690217 

The basic scenario that this solves is that now when you have async logic that updates properties that are bound to the UI, you do not have to worry about thread marshalling issues.

One simple proof is to bind a Collection from an OData response to a grid, then add a new row to the collection, then execute `SaveChangesAsync` on the context/container. If the service returns an object with any modified fields, usually the auto-assigned Key field or other default values for properties then when these values are applied back to the object that is bound to the new row, the app will crash with a cross-thread marshalling exception.

