### PR TITLE
Fixes #86

### DIFF
--- a/src/Unchase.OData.ConnectedService.Shared/Common/Constants.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Common/Constants.cs
@@ -43,6 +43,8 @@ namespace Unchase.OData.ConnectedService.Common
         public const string V4EdmNuGetPackage = "Microsoft.OData.Edm";
         public const string V4SpatialNuGetPackage = "Microsoft.Spatial";
 
+        public const string MSEmbeddedResourcePackage = "Microsoft.Extensions.FileProviders.Embedded";
+
         public const string EdmxVersion1Namespace = "http://schemas.microsoft.com/ado/2007/06/edmx";
         public const string EdmxVersion2Namespace = "http://schemas.microsoft.com/ado/2008/10/edmx";
         public const string EdmxVersion3Namespace = "http://schemas.microsoft.com/ado/2009/11/edmx";

--- a/src/Unchase.OData.ConnectedService.Shared/Models/ServiceConfiguration.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Models/ServiceConfiguration.cs
@@ -90,6 +90,8 @@ namespace Unchase.OData.ConnectedService.Models
 
         public bool IncludeT4File { get; set; }
 
+        public bool EmbedEdmxFile { get; set; }
+
         public bool MakeTypesInternal { get; set; }
     }
 

--- a/src/Unchase.OData.ConnectedService.Shared/Models/UserSettings.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Models/UserSettings.cs
@@ -79,6 +79,9 @@ namespace Unchase.OData.ConnectedService.Models
         public bool IncludeT4File { get; set; }
 
         [DataMember]
+        public bool EmbedEdmxFile { get; set; }
+
+        [DataMember]
         public bool MakeTypesInternal { get; set; }
 
         [DataMember]

--- a/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.cs
@@ -2534,7 +2534,7 @@ public abstract class ODataClientTemplate : TemplateBase
 
         foreach (var propertyInfo in propertyInfos)
         {
-            string privatePropertyName = uniqueIdentifierService.GetUniqueIdentifier("_" + propertyInfo.PropertyName);
+            string privatePropertyName = uniqueIdentifierService.GetUniqueIdentifier("_" + propertyInfo.FixedPropertyName);
 
             this.WritePropertyForStructuredType(
                 propertyInfo.PropertyType,
@@ -2567,7 +2567,7 @@ public abstract class ODataClientTemplate : TemplateBase
         }
     }
 
-    internal string GetFixedName(string originalName)
+    internal virtual string GetFixedName(string originalName)
     {
         string fixedName = originalName;
 
@@ -2830,17 +2830,9 @@ public abstract class TemplateBase
                 throw new global::System.ArgumentNullException("objectToConvert");
             }
             System.Type t = objectToConvert.GetType();
-            System.Reflection.MethodInfo method = t.GetMethod("ToString", new System.Type[] {
-                        typeof(System.IFormatProvider)});
-            if ((method == null))
-            {
-                return objectToConvert.ToString();
-            }
-            else
-            {
-                return ((string)(method.Invoke(objectToConvert, new object[] {
-                            this.formatProviderField })));
-            }
+            System.Reflection.MethodInfo method = t.GetMethod("ToString", new System.Type[] { typeof(System.IFormatProvider)});
+
+            return ((method == null ? objectToConvert.ToString() : ((string)(method.Invoke(objectToConvert, new object[] { this.formatProviderField })))) ?? String.Empty);
         }
     }
     private ToStringInstanceHelper toStringHelperField = new ToStringInstanceHelper();
@@ -3489,6 +3481,18 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     internal override string ParameterDeclarationTemplate => "{0} {1}";
     internal override string DictionaryItemConstructor => "{{ {0}, {1} }}";
 
+    internal override string GetFixedName(string originalName)
+    {
+        string fixedName = originalName;
+
+        if (this.LanguageKeywords.Contains(fixedName))
+        {
+            fixedName = string.Format(this.FixPattern, fixedName);
+        }
+
+        return (fixedName ?? String.Empty).Replace(' ', '_');
+    }
+
     internal override HashSet<string> LanguageKeywords { get {
         if (CSharpKeywords == null)
         {
@@ -3538,7 +3542,7 @@ this.Write("\r\n");
 
 this.Write("namespace ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(fullNamespace));
+this.Write(this.ToStringHelper.ToStringWithCulture(this.GetFixedName(fullNamespace)));
 
 this.Write("\r\n{\r\n");
 
@@ -3860,11 +3864,11 @@ this.Write("                if (!this.IsComposable)\r\n                {\r\n    
 
 this.Write("                if ((this._");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
+this.Write(this.ToStringHelper.ToStringWithCulture(entitySetFixedName));
 
 this.Write(" == null))\r\n                {\r\n                    this._");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
+this.Write(this.ToStringHelper.ToStringWithCulture(entitySetFixedName));
 
 this.Write(" = ");
 
@@ -3880,7 +3884,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(inContext ? "\"" + originalEn
 
 this.Write(");\r\n                }\r\n                return this._");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
+this.Write(this.ToStringHelper.ToStringWithCulture(entitySetFixedName));
 
 this.Write(";\r\n            }\r\n        }\r\n        [global::System.CodeDom.Compiler.GeneratedCo" +
         "deAttribute(\"Microsoft.OData.Client.Design.T4\", \"");
@@ -3893,7 +3897,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(entitySetElementTypeName));
 
 this.Write("> _");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
+this.Write(this.ToStringHelper.ToStringWithCulture(entitySetFixedName));
 
 this.Write(";\r\n");
 
@@ -3950,11 +3954,11 @@ this.Write("                if (!this.IsComposable)\r\n                {\r\n    
 
 this.Write("                if ((this._");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(singletonName));
+this.Write(this.ToStringHelper.ToStringWithCulture(singletonFixedName));
 
 this.Write(" == null))\r\n                {\r\n                    this._");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(singletonName));
+this.Write(this.ToStringHelper.ToStringWithCulture(singletonFixedName));
 
 this.Write(" = new ");
 
@@ -3970,7 +3974,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(inContext ? "\"" + originalSi
 
 this.Write(");\r\n                }\r\n                return this._");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(singletonName));
+this.Write(this.ToStringHelper.ToStringWithCulture(singletonFixedName));
 
 this.Write(";\r\n            }\r\n        }\r\n        [global::System.CodeDom.Compiler.GeneratedCo" +
         "deAttribute(\"Microsoft.OData.Client.Design.T4\", \"");
@@ -3983,7 +3987,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(singletonElementTypeName));
 
 this.Write(" _");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(singletonName));
+this.Write(this.ToStringHelper.ToStringWithCulture(singletonFixedName));
 
 this.Write(";\r\n");
 
@@ -4558,7 +4562,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(privatePropertyName));
 
 this.Write(";\r\n            }\r\n            set\r\n            {\r\n                this.On");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(propertyName));
+this.Write(this.ToStringHelper.ToStringWithCulture(fixedPropertyName));
 
 this.Write("Changing(value);\r\n                this.");
 
@@ -4566,7 +4570,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(privatePropertyName));
 
 this.Write(" = value;\r\n                this.On");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(propertyName));
+this.Write(this.ToStringHelper.ToStringWithCulture(fixedPropertyName));
 
 this.Write("Changed();\r\n");
 
@@ -4600,7 +4604,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(propertyInitializationValue !
 
 this.Write(";\r\n        partial void On");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(propertyName));
+this.Write(this.ToStringHelper.ToStringWithCulture(fixedPropertyName));
 
 this.Write("Changing(");
 
@@ -4608,7 +4612,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(propertyType));
 
 this.Write(" value);\r\n        partial void On");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(propertyName));
+this.Write(this.ToStringHelper.ToStringWithCulture(fixedPropertyName));
 
 this.Write("Changed();\r\n");
 

--- a/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.cs
@@ -49,7 +49,7 @@ namespace Unchase.OData.ConnectedService.Templates
 
             THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             */
-
+            
             try
             {
                 CodeGenerationContext context;
@@ -1812,7 +1812,7 @@ public abstract class ODataClientTemplate : TemplateBase
             if (this.context.EnableNamingAlias)
             {
                 camelCaseEntitySetName = Customization.CustomizeNaming(camelCaseEntitySetName);
-        }
+            }
 
             this.WriteContextAddToEntitySetMethod(camelCaseEntitySetName, entitySet.Name, GetFixedName(entitySetElementTypeName), parameterName);
         }
@@ -1834,7 +1834,7 @@ public abstract class ODataClientTemplate : TemplateBase
                 edmNavigationSourceList.Add(singleton);
             }
         }
-
+        
         this.WriteGeneratedEdmModel(Utils.SerializeToString(this.context.Edmx).Replace("\"", "\"\""));
         
         bool hasOperationImport = container.OperationImports().OfType<IEdmOperationImport>().Any();

--- a/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.cs
@@ -1142,7 +1142,7 @@ public class CodeGenerationContext
             {
                 if (template.LanguageKeywords.Contains(segments[i]))
                 {
-                    prefixedNamespace += string.Format(CultureInfo.InvariantCulture, template.FixPattern, segments[i]);
+                    prefixedNamespace += string.Format(CultureInfo.InvariantCulture, template.FixKeywordPattern, segments[i]);
                 }
                 else
                 {
@@ -1335,7 +1335,12 @@ public abstract class ODataClientTemplate : TemplateBase
     internal abstract string EnumTypeName { get; }
     internal abstract string DictionaryTypeName { get; }
     internal abstract HashSet<string> LanguageKeywords { get; }
-    internal abstract string FixPattern { get; }
+    internal HashSet<string> ReservedMemberNames = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "Context"
+    };
+    internal abstract string FixKeywordPattern { get; }
+    internal string FixReservedMemberNamePattern = "{0}_";
     internal abstract string EnumUnderlyingTypeMarker { get; }
     internal abstract string ConstantExpressionConstructorWithType { get; }
     internal abstract string TypeofFormatter { get; }
@@ -2595,7 +2600,7 @@ public abstract class ODataClientTemplate : TemplateBase
 
         if (this.LanguageKeywords.Contains(fixedName))
         {
-            fixedName = string.Format(this.FixPattern, fixedName);
+            fixedName = string.Format(this.FixKeywordPattern, fixedName);
         }
 
         return fixedName;
@@ -3494,7 +3499,7 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     internal override string XmlConvertClassName => "global::System.Xml.XmlConvert";
     internal override string EnumTypeName => "global::System.Enum";
     internal override string DictionaryTypeName => "global::System.Collections.Generic.Dictionary<{0}, {1}>";
-    internal override string FixPattern => "@{0}";
+    internal override string FixKeywordPattern => "@{0}";
     internal override string EnumUnderlyingTypeMarker => " : ";
     internal override string ConstantExpressionConstructorWithType => "global::System.Linq.Expressions.Expression.Constant({0}, typeof({1}))";
     internal override string TypeofFormatter => "typeof({0})";
@@ -3512,9 +3517,13 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     {
         string fixedName = originalName;
 
+        if (this.ReservedMemberNames.Contains(fixedName))
+        {
+            fixedName = string.Format(this.FixReservedMemberNamePattern, fixedName);
+        }
         if (this.LanguageKeywords.Contains(fixedName))
         {
-            fixedName = string.Format(this.FixPattern, fixedName);
+            fixedName = string.Format(this.FixKeywordPattern, fixedName);
         }
 
         return GetFixedNamePart(fixedName ?? String.Empty);
@@ -3531,8 +3540,7 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
                 "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public",
                 "readonly", "ref", "return", "sbyte", "sealed", "string", "short", "sizeof", "stackalloc", "static", "struct", "switch",
                 "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "volatile",
-                "void", "while",
-                "Context" // Not actually a keyword, but a necessary inherited property
+                "void", "while"
             };
         }
         return CSharpKeywords;
@@ -5692,7 +5700,7 @@ public sealed class ODataClientVBTemplate : ODataClientTemplate
     internal override string XmlConvertClassName { get { return "Global.System.Xml.XmlConvert"; } }
     internal override string EnumTypeName { get { return "Global.System.Enum"; } }
     internal override string DictionaryTypeName { get { return "Global.System.Collections.Generic.Dictionary(Of {0}, {1})"; } }
-    internal override string FixPattern { get { return "[{0}]"; } }
+    internal override string FixKeywordPattern { get { return "[{0}]"; } }
     internal override string EnumUnderlyingTypeMarker { get { return " As "; } }
     internal override string ConstantExpressionConstructorWithType { get { return "Global.System.Linq.Expressions.Expression.Constant({0}, GetType({1}))"; } }
     internal override string TypeofFormatter { get { return "GetType({0})"; } }    
@@ -5725,8 +5733,7 @@ public sealed class ODataClientVBTemplate : ODataClientTemplate
                 "Select", "Set", "Shadows", "Shared", "Short", "Single", "Static", "Step", "Stop", "String", 
                 "Structure", "Sub", "SyncLock", "Then", "Throw", "To", "True", "Try", "TryCast", "TypeOf", 
                 "UInteger", "ULong", "UShort", "Using", "Variant", "Wend", "When", "While", "Widening", "With", 
-                "WithEvents", "WriteOnly", "Xor",
-                "Context" // Not actually a keyword, but a necessary inherited property
+                "WithEvents", "WriteOnly", "Xor"
             };
         }
         return VBKeywords;

--- a/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Unchase.OData.ConnectedService.Shared/Templates/ODataT4CodeGenerator.ttinclude
@@ -2497,7 +2497,7 @@ public abstract class ODataClientTemplate : TemplateBase
         }
     }
 
-    internal string GetFixedName(string originalName)
+    internal virtual string GetFixedName(string originalName)
     {
         string fixedName = originalName;
 
@@ -3442,6 +3442,19 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     internal override string ODataVersion { get { return "global::Microsoft.OData.ODataVersion.V4"; } }
     internal override string ParameterDeclarationTemplate { get { return "{0} {1}"; } }
     internal override string DictionaryItemConstructor { get { return "{{ {0}, {1} }}"; } }
+
+    internal override string GetFixedName(string originalName)
+    {
+        string fixedName = originalName;
+
+        if (this.LanguageKeywords.Contains(fixedName))
+        {
+            fixedName = string.Format(this.FixPattern, fixedName);
+        }
+
+        return (fixedName ?? String.Empty).Replace(' ', '_');
+    }
+
     internal override HashSet<string> LanguageKeywords { get {
         if (CSharpKeywords == null)
         {

--- a/src/Unchase.OData.ConnectedService.Shared/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/ViewModels/AdvancedSettingsViewModel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.VisualStudio.ConnectedServices;
 using Microsoft.VisualStudio.Debugger.Interop;
-using Unchase.OData.ConnectedService.Common;
+using Common = Unchase.OData.ConnectedService.Common;
 using Unchase.OData.ConnectedService.Models;
 using Unchase.OData.ConnectedService.Views;
 
@@ -16,8 +16,8 @@ namespace Unchase.OData.ConnectedService.ViewModels
     internal class AdvancedSettingsViewModel : ConnectedServiceWizardPage
     {
         #region Properties and fields
-        public Constants.OperationImportsGenerator[] OperationImportsGenerators =>
-            new[] { Constants.OperationImportsGenerator.Inner, Constants.OperationImportsGenerator.SimpleOData};
+        public Common.Constants.OperationImportsGenerator[] OperationImportsGenerators =>
+            new[] { Common.Constants.OperationImportsGenerator.Inner, Common.Constants.OperationImportsGenerator.SimpleOData};
 
         #region UseDataServiceCollection
         private bool _useDataServiceCollection;
@@ -231,8 +231,8 @@ namespace Unchase.OData.ConnectedService.ViewModels
         #endregion
 
         #region OperationImportsGenerator
-        private Constants.OperationImportsGenerator _operationImportsGenerator;
-        public Constants.OperationImportsGenerator OperationImportsGenerator
+        private Common.Constants.OperationImportsGenerator _operationImportsGenerator;
+        public Common.Constants.OperationImportsGenerator OperationImportsGenerator
         {
             get => _operationImportsGenerator;
             set
@@ -301,13 +301,13 @@ namespace Unchase.OData.ConnectedService.ViewModels
             this.UseDataServiceCollection = UserSettings.UseDataServiceCollection;
             this.UseAsyncDataServiceCollection = UserSettings.UseAsyncDataServiceCollection;
             this.UseNamespacePrefix = UserSettings.UseNameSpacePrefix;
-            this.NamespacePrefix = UserSettings.NamespacePrefix ?? Constants.DefaultNamespacePrefix;
+            this.NamespacePrefix = UserSettings.NamespacePrefix ?? Common.Constants.DefaultNamespacePrefix;
             this.EnableNamingAlias = UserSettings.EnableNamingAlias;
             this.IgnoreUnexpectedElementsAndAttributes = UserSettings.IgnoreUnexpectedElementsAndAttributes;
             this.GenerateDynamicPropertiesCollection = UserSettings.GenerateDynamicPropertiesCollection;
             this.DynamicPropertiesCollectionName = UserSettings.DynamicPropertiesCollectionName;
             this.GeneratedFileNameEnabled = true;
-            this.GeneratedFileNamePrefix = UserSettings.GeneratedFileNamePrefix ?? Constants.DefaultReferenceFileName;
+            this.GeneratedFileNamePrefix = UserSettings.GeneratedFileNamePrefix ?? Common.Constants.DefaultReferenceFileName;
             this.IncludeT4FileEnabled = true;
             this.IncludeT4File = UserSettings.IncludeT4File;
             this.EmbedEdmxFileEnabled = true;

--- a/src/Unchase.OData.ConnectedService.Shared/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/ViewModels/AdvancedSettingsViewModel.cs
@@ -6,6 +6,7 @@ using System.Data.Services.Design;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.VisualStudio.ConnectedServices;
+using Microsoft.VisualStudio.Debugger.Interop;
 using Unchase.OData.ConnectedService.Common;
 using Unchase.OData.ConnectedService.Models;
 using Unchase.OData.ConnectedService.Views;
@@ -183,6 +184,24 @@ namespace Unchase.OData.ConnectedService.ViewModels
         }
         #endregion
 
+        #region EmbedEdmxFileEnabled
+        public bool EmbedEdmxFileEnabled { get; set; }
+        #endregion
+
+        #region EmbedEdmxFile
+        private bool _embedEdmxFile;
+        public bool EmbedEdmxFile
+        {
+            get => _embedEdmxFile;
+            set
+            {
+                _embedEdmxFile = value;
+                UserSettings.EmbedEdmxFile = value;
+                OnPropertyChanged(nameof(EmbedEdmxFile));
+            }
+        }
+        #endregion
+
         #region MakeTypesInternal
         private bool _makeTypesInternal;
         public bool MakeTypesInternal
@@ -291,6 +310,8 @@ namespace Unchase.OData.ConnectedService.ViewModels
             this.GeneratedFileNamePrefix = UserSettings.GeneratedFileNamePrefix ?? Constants.DefaultReferenceFileName;
             this.IncludeT4FileEnabled = true;
             this.IncludeT4File = UserSettings.IncludeT4File;
+            this.EmbedEdmxFileEnabled = true;
+            this.EmbedEdmxFile = UserSettings.EmbedEdmxFile;
             this.MakeTypesInternal = UserSettings.MakeTypesInternal;
             this.IncludeExtensionsT4File = UserSettings.IncludeExtensionsT4File;
             this.OperationImportsGenerator = UserSettings.OperationImportsGenerator;

--- a/src/Unchase.OData.ConnectedService.Shared/Views/AdvancedSettings.xaml
+++ b/src/Unchase.OData.ConnectedService.Shared/Views/AdvancedSettings.xaml
@@ -9,19 +9,20 @@
     d:DesignHeight="460"
     d:DesignWidth="500"
     mc:Ignorable="d">
-    <StackPanel Margin="0,0,0,-193">
-        <StackPanel
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <StackPanel
             x:Name="SettingsPanel"
             Height="125"
             Margin="10,0,0,0"
             HorizontalAlignment="Left"
             VerticalAlignment="Top">
-            <TextBlock
+                <TextBlock
                 x:Name="ReferenceFileNameLabel"
                 Margin="0,5,0,0"
                 HorizontalAlignment="Left"
                 Text="Enter the file name (without extension):" />
-            <TextBox
+                <TextBox
                 x:Name="ReferenceFileName"
                 Width="480"
                 Margin="20,5,0,0"
@@ -30,35 +31,35 @@
                 IsEnabled="{Binding GeneratedFileNameEnabled, Mode=TwoWay}"
                 Text="{Binding UserSettings.GeneratedFileNamePrefix, Mode=TwoWay}"
                 TextWrapping="Wrap" />
-            <TextBlock
+                <TextBlock
                 x:Name="Label"
                 Margin="0,20,40,0"
                 TextWrapping="WrapWithOverflow">
                 You can generate the client proxy based on the default settings, or you can click following link for further configuration.
-            </TextBlock>
-            <TextBlock
+                </TextBlock>
+                <TextBlock
                 x:Name="TextBlock"
                 Margin="0,5"
                 TextWrapping="Wrap">
                 <Hyperlink Name="Settings" Click="settings_Click">AdvancedSettings</Hyperlink>
-            </TextBlock>
-        </StackPanel>
-        <StackPanel x:Name="AdvancedSettingsPanel">
-            <StackPanel
+                </TextBlock>
+            </StackPanel>
+            <StackPanel x:Name="AdvancedSettingsPanel">
+                <StackPanel
                 Margin="10,5,0,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top">
-                <CheckBox
+                    <CheckBox
                     x:Name="UseNamespacePrefix"
                     Margin="0,5"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Bottom"
                     IsChecked="{Binding UserSettings.UseNameSpacePrefix, Mode=TwoWay}">
-                    <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">
+                        <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">
                         Use a custom namespace (It will replace the original namespace in the metadata document, unless the model has several namespaces).
-                    </TextBlock>
-                </CheckBox>
-                <TextBox
+                        </TextBlock>
+                    </CheckBox>
+                    <TextBox
                     x:Name="NamespacePrefix"
                     Width="480"
                     Margin="20,0,0,5"
@@ -66,15 +67,15 @@
                     VerticalAlignment="Center"
                     Text="{Binding UserSettings.NamespacePrefix, Mode=TwoWay}"
                     TextWrapping="Wrap" />
-                <StackPanel Margin="0,5,0,0" Orientation="Horizontal">
-                    <CheckBox
+                    <StackPanel Margin="0,5,0,0" Orientation="Horizontal">
+                        <CheckBox
                         x:Name="UseDsc"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Top"
                         Content="Enable entity and property tracking."
                         IsChecked="{Binding UserSettings.UseDataServiceCollection, Mode=TwoWay}" />
-                    <TextBlock Margin="10,0,0,0">-</TextBlock>
-                    <CheckBox
+                        <TextBlock Margin="10,0,0,0">-</TextBlock>
+                        <CheckBox
                         x:Name="UseAsyncDsc"
                         Margin="10,0,0,0"
                         HorizontalAlignment="Left"
@@ -82,8 +83,8 @@
                         Content="Implement async binding base. (c# only)"
                         IsChecked="{Binding UserSettings.UseAsyncDataServiceCollection, Mode=TwoWay}"
                         Visibility="{Binding UserSettings.UseDataServiceCollection}" />
-                </StackPanel>
-                <CheckBox
+                    </StackPanel>
+                    <CheckBox
                     x:Name="SelectOperationImports"
                     Width="450"
                     Height="20"
@@ -95,14 +96,14 @@
                     FontWeight="Medium"
                     IsChecked="{Binding UserSettings.SelectOperationImports, Mode=TwoWay}"
                     Unchecked="SelectOperationImports_OnUnchecked" />
-                <StackPanel x:Name="ExtensionMethodsForCSharpStackPanel">
-                    <TextBlock
+                    <StackPanel x:Name="ExtensionMethodsForCSharpStackPanel">
+                        <TextBlock
                         x:Name="ExtensionsTemplateLabel"
                         Margin="0,0,10,5"
                         HorizontalAlignment="Left"
                         Text="Extensions:"
                         Visibility="{Binding IncludeExtensionsT4FileVisibility, Mode=TwoWay}" />
-                    <CheckBox
+                        <CheckBox
                         x:Name="IncludeExtensionsT4File"
                         Width="450"
                         Height="25"
@@ -113,15 +114,15 @@
                         FontWeight="Medium"
                         IsChecked="{Binding UserSettings.IncludeExtensionsT4File, Mode=TwoWay}"
                         Visibility="{Binding IncludeExtensionsT4FileVisibility, Mode=TwoWay}" />
-                    <StackPanel x:Name="FunctionImportsStackPanel" Visibility="Collapsed">
-                        <TextBlock
+                        <StackPanel x:Name="FunctionImportsStackPanel" Visibility="Collapsed">
+                            <TextBlock
                             x:Name="ExtensionsFunctionImportsGeneratorLabel"
                             Margin="0,10,10,5"
                             HorizontalAlignment="Left"
                             IsEnabled="{Binding ElementName=IncludeExtensionsT4File, Path=IsChecked}"
                             Text="OData methods generation method (from FunctionImports):"
                             Visibility="{Binding IncludeExtensionsT4FileVisibility, Mode=TwoWay}" />
-                        <ComboBox
+                            <ComboBox
                             x:Name="FunctionImportsGenerationMethod"
                             Width="480"
                             Height="25"
@@ -134,47 +135,47 @@
                             SelectedIndex="0"
                             SelectedValue="{Binding OperationImportsGenerator}"
                             Visibility="{Binding IncludeExtensionsT4FileVisibility, Mode=TwoWay}" />
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
-            </StackPanel>
-            <StackPanel
+                <StackPanel
                 x:Name="AdvancedSettingsForv4"
                 Margin="10,5,0,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top">
-                <CheckBox
+                    <CheckBox
                     x:Name="EnableCamelCase"
                     Margin="0,5"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
                     Content="Use c# casing style."
                     IsChecked="{Binding UserSettings.EnableNamingAlias, Mode=TwoWay}" />
-                <CheckBox
+                    <CheckBox
                     x:Name="IgnoreUnknownAttributeOrElement"
                     Margin="0,5"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
                     IsChecked="{Binding UserSettings.IgnoreUnexpectedElementsAndAttributes, Mode=TwoWay}">
-                    <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">Ignore unknown elements (Whether to ignore unexpected elements and attributes in the metadata document and generate the client code if any).</TextBlock>
-                </CheckBox>
-                <CheckBox
+                        <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">Ignore unknown elements (Whether to ignore unexpected elements and attributes in the metadata document and generate the client code if any).</TextBlock>
+                    </CheckBox>
+                    <CheckBox
                     x:Name="MakeTypesInternal"
                     Margin="0,5"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
                     IsChecked="{Binding UserSettings.MakeTypesInternal, Mode=TwoWay}">
-                    <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">Make generated types internal (Enable this if you don't want to expose the generated types outside of your assembly).</TextBlock>
-                </CheckBox>
+                        <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">Make generated types internal (Enable this if you don't want to expose the generated types outside of your assembly).</TextBlock>
+                    </CheckBox>
 
-                <CheckBox
+                    <CheckBox
                     x:Name="GenerateDynamicPropertiesCollection"
                     Margin="0,5"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
                     IsChecked="{Binding UserSettings.GenerateDynamicPropertiesCollection, Mode=TwoWay}">
-                    <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">Generate Dynamic Properties Collection with name :</TextBlock>
-                </CheckBox>
-                <TextBox
+                        <TextBlock Margin="0,0,40,0" TextWrapping="Wrap">Generate Dynamic Properties Collection with name :</TextBlock>
+                    </CheckBox>
+                    <TextBox
                     x:Name="DynamicPropertiesCollectionName"
                     Width="480"
                     Margin="20,0,0,5"
@@ -183,7 +184,7 @@
                     Text="{Binding UserSettings.DynamicPropertiesCollectionName, Mode=TwoWay}"
                     TextWrapping="Wrap" />
 
-                <CheckBox
+                    <CheckBox
                     x:Name="EmbedEdmxFile"
                     Width="500"
                     Height="25"
@@ -195,7 +196,7 @@
                     IsChecked="{Binding UserSettings.EmbedEdmxFile, Mode=TwoWay}"
                     IsEnabled="{Binding EmbedEdmxFileEnabled, Mode=TwoWay}" />
 
-                <CheckBox
+                    <CheckBox
                     x:Name="IncludeT4File"
                     Width="500"
                     Height="25"
@@ -206,10 +207,10 @@
                     FontWeight="Medium"
                     IsChecked="{Binding UserSettings.IncludeT4File, Mode=TwoWay}"
                     IsEnabled="{Binding IncludeT4FileEnabled, Mode=TwoWay}" />
-                <TextBlock Margin="20,0,40,0" TextWrapping="Wrap">
+                    <TextBlock Margin="20,0,40,0" TextWrapping="Wrap">
                     OperationImports (ActionImports and FunctionImports) names in metadata to exclude from generated code (comma separated):
-                </TextBlock>
-                <TextBox
+                    </TextBlock>
+                    <TextBox
                     x:Name="ExcludedOperationImportsNames"
                     Width="480"
                     Margin="20,10,0,5"
@@ -217,7 +218,8 @@
                     VerticalAlignment="Center"
                     Text="{Binding UserSettings.ExcludedOperationImportsNames, Mode=TwoWay}"
                     TextWrapping="Wrap" />
+                </StackPanel>
             </StackPanel>
         </StackPanel>
-    </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/src/Unchase.OData.ConnectedService.Shared/Views/AdvancedSettings.xaml
+++ b/src/Unchase.OData.ConnectedService.Shared/Views/AdvancedSettings.xaml
@@ -9,7 +9,7 @@
     d:DesignHeight="460"
     d:DesignWidth="500"
     mc:Ignorable="d">
-    <StackPanel>
+    <StackPanel Margin="0,0,0,-193">
         <StackPanel
             x:Name="SettingsPanel"
             Height="125"
@@ -81,7 +81,6 @@
                         VerticalAlignment="Top"
                         Content="Implement async binding base. (c# only)"
                         IsChecked="{Binding UserSettings.UseAsyncDataServiceCollection, Mode=TwoWay}"
-                        IsEnabled="{Binding UserSettings.ShowAsyncDataServiceCollectionOption}"
                         Visibility="{Binding UserSettings.UseDataServiceCollection}" />
                 </StackPanel>
                 <CheckBox
@@ -183,6 +182,18 @@
                     VerticalAlignment="Center"
                     Text="{Binding UserSettings.DynamicPropertiesCollectionName, Mode=TwoWay}"
                     TextWrapping="Wrap" />
+
+                <CheckBox
+                    x:Name="EmbedEdmxFile"
+                    Width="500"
+                    Height="25"
+                    Margin="0,5"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Content="Embed Edmx file (use this if your Edmx is too long for a string literal)."
+                    FontWeight="Medium"
+                    IsChecked="{Binding UserSettings.EmbedEdmxFile, Mode=TwoWay}"
+                    IsEnabled="{Binding EmbedEdmxFileEnabled, Mode=TwoWay}" />
 
                 <CheckBox
                     x:Name="IncludeT4File"

--- a/src/Unchase.OData.ConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
@@ -78,6 +78,7 @@ namespace Unchase.OData.ConnectedService.Views
                 this.UserSettings.GenerateDynamicPropertiesCollection = microsoftConnectedServiceData.ExtendedData?.GenerateDynamicPropertiesCollection ?? this.UserSettings.GenerateDynamicPropertiesCollection;
                 this.UserSettings.DynamicPropertiesCollectionName = microsoftConnectedServiceData.ExtendedData?.DynamicPropertiesCollectionName ?? this.UserSettings.DynamicPropertiesCollectionName;
                 this.UserSettings.IncludeT4File = microsoftConnectedServiceData.ExtendedData?.IncludeT4File ?? this.UserSettings.IncludeT4File;
+                this.UserSettings.EmbedEdmxFile = microsoftConnectedServiceData.ExtendedData?.EmbedEdmxFile ?? this.UserSettings.EmbedEdmxFile;
                 this.UserSettings.MakeTypesInternal = microsoftConnectedServiceData.ExtendedData?.MakeTypesInternal ?? this.UserSettings.MakeTypesInternal;
                 this.UserSettings.LanguageOption = microsoftConnectedServiceData.ExtendedData?.LanguageOption ?? this.UserSettings.LanguageOption;
                 this.UserSettings.OperationImportsGenerator = microsoftConnectedServiceData.ExtendedData?.OperationImportsGenerator ?? this.UserSettings.OperationImportsGenerator;

--- a/src/Unchase.OData.ConnectedService.Shared/Wizard.cs
+++ b/src/Unchase.OData.ConnectedService.Shared/Wizard.cs
@@ -86,8 +86,10 @@ namespace Unchase.OData.ConnectedService
                     AdvancedSettingsViewModel.DynamicPropertiesCollectionName = serviceConfig.DynamicPropertiesCollectionName;
                     AdvancedSettingsViewModel.EnableNamingAlias = serviceConfig.EnableNamingAlias;
                     AdvancedSettingsViewModel.IncludeT4File = serviceConfig.IncludeT4File;
+                    AdvancedSettingsViewModel.EmbedEdmxFile = serviceConfig.EmbedEdmxFile;
                     AdvancedSettingsViewModel.MakeTypesInternal = serviceConfig.MakeTypesInternal;
                     AdvancedSettingsViewModel.IncludeT4FileEnabled = true;
+                    AdvancedSettingsViewModel.EmbedEdmxFileEnabled = true;
                 }
 
                 // Restore the advanced settings to UI elements.
@@ -115,9 +117,12 @@ namespace Unchase.OData.ConnectedService
                                 advancedSettingsViewModel.DynamicPropertiesCollectionName = serviceConfig.DynamicPropertiesCollectionName;
                                 advancedSettingsViewModel.EnableNamingAlias = serviceConfig.EnableNamingAlias;
                                 advancedSettingsViewModel.IncludeT4File = serviceConfig.IncludeT4File;
+                                advancedSettingsViewModel.EmbedEdmxFile = serviceConfig.EmbedEdmxFile;
                                 advancedSettingsViewModel.MakeTypesInternal = serviceConfig.MakeTypesInternal;
                                 advancedSettingsViewModel.IncludeT4FileEnabled = true;
                                 advancedSettings.IncludeT4File.IsEnabled = true;
+                                advancedSettingsViewModel.EmbedEdmxFileEnabled = true;
+                                advancedSettings.EmbedEdmxFile.IsEnabled = true;
                             }
 
                             if (!advancedSettingsViewModel.SelectOperationImports || UserSettings.LanguageOption != LanguageOption.GenerateCSharpCode)
@@ -143,6 +148,7 @@ namespace Unchase.OData.ConnectedService
                     advancedSettingsViewModel.OperationImportsGenerator = AdvancedSettingsViewModel.OperationImportsGenerator;
                     advancedSettingsViewModel.SelectOperationImports = AdvancedSettingsViewModel.SelectOperationImports;
                     advancedSettingsViewModel.IncludeT4FileEnabled = true;
+                    advancedSettingsViewModel.EmbedEdmxFileEnabled = true;
                     if (!advancedSettingsViewModel.SelectOperationImports || UserSettings.LanguageOption != LanguageOption.GenerateCSharpCode)
                         RemoveOperationImportsSettingsPage();
                     else
@@ -237,6 +243,7 @@ namespace Unchase.OData.ConnectedService
                     DynamicPropertiesCollectionName = AdvancedSettingsViewModel.UserSettings.DynamicPropertiesCollectionName,
                     EnableNamingAlias = AdvancedSettingsViewModel.UserSettings.EnableNamingAlias,
                     IncludeT4File = AdvancedSettingsViewModel.UserSettings.IncludeT4File,
+                    EmbedEdmxFile = AdvancedSettingsViewModel.UserSettings.EmbedEdmxFile,
                     MakeTypesInternal = AdvancedSettingsViewModel.UserSettings.MakeTypesInternal
                 };
             }


### PR DESCRIPTION
I'm not 100% happy with this as I am sure I left a lot of stuff untouched that needed updating, but it works for my specific case.

- Replaces spaces with underscores in member names in C#
- Uses underscore instead of @ for reserved words in C#, so it can be used in private members
- Adds 'Context' to list of reserved words, to prevent hiding necessary inherited member
- Adds an option to write the Edmx as an embedded file instead of a string literal